### PR TITLE
fixing moment's fromNow show when fall-back

### DIFF
--- a/app/assets/js/main.js
+++ b/app/assets/js/main.js
@@ -55,7 +55,10 @@
         initTimeAgo: function(){
             moment.lang('zh-cn');
             $('.timeago').each(function(){
-                $(this).text( moment( $(this).text() ).fromNow());
+                var time_str = $(this).text();
+                if(moment(time_str, "YYYY-MM-DD HH:mm:ss", true).isValid()) {
+                    $(this).text( moment( new Date(time_str) ).fromNow());
+                }
             });
         },
 


### PR DESCRIPTION
在chrome下（其他浏览器暂未测试），从 `topics` 列表页面到 `topics`的具体页面后，点击**返回**按钮后，页面上的`timeago`显示的时间全部为 `几秒前`，如图：
**半夜在家传图传了半天挂了，换个体位也不行，囧，下面都不上图了**

看到`console`里面提示这样的：
`Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.`
查看这个`issues`后以为是修改`moment( $(this).text() ).fromNow()`为 `moment( new Date(time_str) ).fromNow()` 就可以了，确实那个`warning`没有了，不过依然是显示`几秒前`。
问题依然。

于是将现在的momentjs从2.7.0升级到2.8.2问题依然。

开始考虑不是momentjs的问题了。偶然发现在`moment( $(this).text() ).fromNow()`之前，通过`console.log($(this).text())`打印出值的方法找到了问题：
在按`返回`或者`前进`的情况下打印出的竟然是`几秒前`，于是在此之前加上了时间判断是否为正确的时间，`moment(time_str, "YYYY-MM-DD HH:mm:ss", true).isValid()`这个moment的构造时第三个参数必须传，不然`几秒前`也返回`true`，真囧。

搞定之后想了一下这个问题的所在，应该就是在返回或者前进时候的页面并不是从服务器端获取的，从而显示的是处理的类似`几秒前`之类的返回值（当然在moment的内部这个时间传值处理后为NaN），但是依然触发了pjax的pjax:end事件，从而让`siteBootUp`再次执行了。

这个问题真隐蔽，想不到浏览器这里的‘手脚’，找了大半夜，赶紧睡了～

注：momentjs的[新版本提示](http://momentjs.com/docs/#/i18n/changing-locale/)了`moment.lang()`这个方法不建议了，建议使用`moment.locale()`
