### PR TITLE
fix Bugsnag function redeclare error

### DIFF
--- a/app/start/global.php
+++ b/app/start/global.php
@@ -42,9 +42,7 @@ Log::useDailyFiles(storage_path().'/logs/'.$logFile);
 */
 // Bugsnag::setReleaseStage("production");
 Bugsnag::setErrorReportingLevel(E_ALL & ~E_NOTICE);
-Bugsnag::setBeforeNotifyFunction("before_bugsnag_notify");
-
-function before_bugsnag_notify($error) {
+Bugsnag::setBeforeNotifyFunction(function($error) {
     // Do any custom error handling here
 
     // Also add some meta data to each error
@@ -54,7 +52,7 @@ function before_bugsnag_notify($error) {
             "user" => $user
         ));
     }
-}
+});
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
最近的几次提交 travis-ci 都是失败，查看日志发现
![image](https://cloud.githubusercontent.com/assets/2189610/6438229/2d7ca660-c102-11e4-89ce-ff8b92ddf1ae.png)

查询 phphub 源码没发现重复定义的地方，不知道是不是和 travis-ci 有冲突，而且在这里直接定义也不太好，容易有冲突。

查看 BugsnagLaravel [源码](https://github.com/bugsnag/bugsnag-laravel/blob/master/src/Bugsnag/BugsnagLaravel/BugsnagLaravelServiceProvider.php#L49)可以看到返回的 facade 是 `Bugsnag_Client`, 并且存在 `setBeforeNotifyFunction` 方法。
而最终发送通知的时候会调用 [这个方法](https://github.com/bugsnag/bugsnag-php/blob/master/src/Bugsnag/Notification.php#L39-L41)，可以看到是允许匿名函数的。

