### PR TITLE
fixed: fail to get email if user does not set public email

### DIFF
--- a/app/Phphub/Github/GithubUserDataReader.php
+++ b/app/Phphub/Github/GithubUserDataReader.php
@@ -15,6 +15,7 @@ class GithubUserDataReader
         $github = OAuth::consumer('GitHub');
         $oauthTokenObject = $github->requestAccessToken($code);
         $githubData = json_decode($github->request('user'), true);
+        $githubData['email'] = !isset($githubData['email']) ?: last(json_decode($github->request('user/emails'), true));
         $emails = json_decode($github->request('user/emails'), true);
         $githubData['emails'] = array_combine($emails, $emails);
         return $githubData;

--- a/app/Phphub/Github/GithubUserDataReader.php
+++ b/app/Phphub/Github/GithubUserDataReader.php
@@ -15,9 +15,9 @@ class GithubUserDataReader
         $github = OAuth::consumer('GitHub');
         $oauthTokenObject = $github->requestAccessToken($code);
         $githubData = json_decode($github->request('user'), true);
-        $githubData['email'] = !isset($githubData['email']) ?: last(json_decode($github->request('user/emails'), true));
         $emails = json_decode($github->request('user/emails'), true);
         $githubData['emails'] = array_combine($emails, $emails);
+        $githubData['email'] = !isset($githubData['email']) ?: last($emails);
         return $githubData;
     }
 


### PR DESCRIPTION
fix this pull request #85 
fix $githubData['email'] could not get value if user set "Dont't show my email address"
it will use last email has been found in user/emails

TODO:
set $githubData['email'] to use primary email with [github api v3](https://developer.github.com/v3/users/emails/)