### PR TITLE
travis: removed branch exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ php:
   - 5.5
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: hhvm
-
 branches:
   except:
     - gh-pages


### PR DESCRIPTION
- there is only `master` branch, so no need for this