### PR TITLE
fixing logical operator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ The [phphub.org](http://phphub.org) site is entirely open source, and community 
  If you have any questions please don't hesitate to ask them in an issue or email me at phphub.org@gmail.com.
 
 [![Build Status](https://api.travis-ci.org/summerblue/phphub.svg?branch=master)](https://travis-ci.org/summerblue/phphub)
+[![Code Climate](https://codeclimate.com/github/summerblue/phphub/badges/gpa.svg)](https://codeclimate.com/github/summerblue/phphub)
 
 ### Screen Shots
 

--- a/server.php
+++ b/server.php
@@ -11,7 +11,7 @@ $requested = $paths['public'].$uri;
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ($uri !== '/' and file_exists($requested))
+if ($uri !== '/' && file_exists($requested))
 {
 	return false;
 }


### PR DESCRIPTION
I'm testing out the value of the checks in psecio-parse, so I scanned your repo and found a logical operator in word form instead of symbol form. Using the words instead of the symbol versions of the logical operators can cause precedence bugs, so I updated it for you. I also added the Code Climate badge to your readme in case you'd like to see more of this kind of analysis for your code. 