### PR TITLE
[Proposal] 代码块样式优化

### DIFF
--- a/app/assets/sass/markdown.scss
+++ b/app/assets/sass/markdown.scss
@@ -43,16 +43,6 @@
     height: 0;
   }
 
-  pre {
-    overflow: auto;
-  }
-
-  code,
-  pre {
-    font-family: monospace, monospace;
-    font-size: 1em;
-  }
-
   table {
     border-collapse: collapse;
     border-spacing: 0;
@@ -154,12 +144,14 @@
 
   code,
   pre {
-    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-family: monaco, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size:1em;
   }
 
   pre {
     margin-top: 0;
     margin-bottom: 0;
+    overflow: auto;
   }
 
   .markdown-body>*:first-child {
@@ -386,7 +378,7 @@
     background-color: #4e4e4e;
     border-radius: 3px;
     color: #fff;
-    border: 1px dashed #ccc;
+    border: none;
   }
 
   .highlight pre {


### PR DESCRIPTION
- 去除 `pre` 的虚线边框
- `code` 优先字体：`Monaco`

当然只是个人感觉哈，如果不喜欢就pass吧，哈哈 :smile: 

## Before:

![qq20150703-4 2x](https://cloud.githubusercontent.com/assets/1472352/8491270/c041ebce-2168-11e5-92a5-3573587c099f.jpg)


## After

![qq20150703-3 2x](https://cloud.githubusercontent.com/assets/1472352/8491276/c5c55acc-2168-11e5-813c-7f36d8d516f6.jpg)


