### PR TITLE
Update .styleci.yml

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,6 +3,3 @@ preset: psr2
 enabled:  
       - strict
       - strict_param 
-
-disabled:  
-      - short_array_syntax


### PR DESCRIPTION
The short array synax fixer isn't enabled by the psr2 preset, so your analyses were failing with a missconfiguration error.